### PR TITLE
Adding JSON headers to GetItem requests. Fixes #8

### DIFF
--- a/Infinity/Clients/GitClient.cs
+++ b/Infinity/Clients/GitClient.cs
@@ -256,6 +256,9 @@ namespace Infinity.Clients
             var request = new TfsRestRequest("/_apis/git/repositories/{RepositoryId}/items");
             request.AddUrlSegment("RepositoryId", repositoryId.ToString());
 
+            // This header instructs VSO to return metadata rather than the item contents
+            request.AddHeader("Accept", "application/json");
+
             filters = filters ?? new ItemFilters();
 
             request.AddParameter("scopePath", path);
@@ -287,6 +290,9 @@ namespace Infinity.Clients
 
             var request = new TfsRestRequest("/_apis/git/repositories/{RepositoryId}/itemsBatch", HttpMethod.Post);
             request.AddUrlSegment("RepositoryId", repositoryId.ToString());
+
+            // This header instructs VSO to return metadata rather than the item contents
+            request.AddHeader("Accept", "application/json");
 
             request.AddBody(new
             {


### PR DESCRIPTION
Adding accept JSON headers to ensure `GetItem` and `GetItems` returns metadata instead of file contents.